### PR TITLE
Add Japanese docs and test script

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -4,6 +4,8 @@
 [![Pythonバージョン](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/)
 [![依存関係](https://img.shields.io/badge/dependencies-see%20below-orange)](README.md#-dependencies)
 
+[English](README.md)
+
 **AQE**は量子コンピュータ時代に対応した次世代暗号ライブラリです。従来の楕円曲線暗号と最先端の格子ベース暗号をハイブリッド方式で組み合わせ、現在および将来にわたるセキュリティを確保します。
 
 ## 🌟 主要特徴
@@ -37,6 +39,8 @@ pip install .
 ## 📚 基本的な使い方
 
 以下は基本的な実装例です：
+
+より詳しい使用例は [docs/USAGE_JA.md](docs/USAGE_JA.md) を参照してください。
 
 ```python
 import asyncio

--- a/docs/USAGE_JA.md
+++ b/docs/USAGE_JA.md
@@ -1,0 +1,44 @@
+# AQE 使い方ガイド
+
+このドキュメントでは、AQE ライブラリの基本的な利用方法を日本語で解説します。
+
+## セットアップ
+
+```
+python -m pip install .
+```
+
+## 鍵交換の実行
+
+```python
+import asyncio
+from AQE import QuantumSafeKEX, ConfigurationManager
+
+async def main():
+    config_manager = ConfigurationManager('config.ini')
+    alice = QuantumSafeKEX(config_manager=config_manager, is_initiator=True)
+    bob = QuantumSafeKEX(config_manager=config_manager, is_initiator=False)
+
+    alice_awa = alice.awa
+    bob_awa = bob.awa
+
+    shared_secret_alice, ciphertext = await alice.exchange(bob_awa)
+    shared_secret_bob = await bob.decap(ciphertext, alice_awa)
+
+    assert shared_secret_alice == shared_secret_bob
+
+asyncio.run(main())
+```
+
+## 暗号化トランスポートの使用
+
+```python
+from AQE.transport import SecureTransport
+
+transport = SecureTransport(initial_key=shared_secret_alice, config_manager=config_manager)
+
+cipher = await transport.encrypt(b"hello")
+plain = await transport.decrypt(cipher)
+```
+
+より詳細な例は `example/` ディレクトリを参照してください。

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python -m unittest discover -s tests -v


### PR DESCRIPTION
## Summary
- add usage guide in Japanese under `docs/`
- link to the guide from the Japanese README and add link to English README
- provide helper script `run_tests.sh` to run the unit tests

## Testing
- `./run_tests.sh` *(fails: ImportError and IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_6853f17bcf848326b8690121715be885